### PR TITLE
[FIX] run at `document_start` instead of `document_idle`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,11 @@
   "manifest_version": 3,
   "name": "opw github",
   "description": "add link to odoo issue system on github",
-  "version": "1.1.0.0",
+  "version": "1.1.0.1",
   "content_scripts": [
     {
       "matches": ["*://github.com/odoo/*", "*://github.com/odoo-dev/*"],
+      "run_at": "document_start",
       "js": ["e.js"]
     }
   ],


### PR DESCRIPTION
By default, extension scripts are run after the DOM is complete. This may take longer than `turbo:load` firing, leading to the script waiting for an event that has already taken place.

This can be fixed by registering the event listener as soon as the document starts loading.